### PR TITLE
Enhance Write-Status logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,25 @@ The `agents/` folder hosts TypeScript code while `src/` is reserved for PowerShe
 
 For more detail see [PowerShell Guidelines](docs/PowerShell-Guidelines.md).
 
+## Write-Status Logging Utility
+
+`Write-Status` standardizes messaging across scripts. It honors PowerShell
+preference variables and logs every entry to a file.
+
+```powershell
+# Basic usage
+Write-Status -Level INFO -Message 'Starting build'
+
+# Redirect logs
+Write-Status -Level WARN -Message 'Low disk space' -LogFile 'C:\temp\build.log'
+
+# Pipeline support
+'Finished' | Write-Status -Level SUCCESS -Fast
+```
+
+`Write-Status` maps levels to `Write-Verbose`, `Write-Warning`, `Write-Error` or
+`Write-Debug`, so built-in switches like `-Verbose` control console output.
+
 ## Contributing
 
 Contributions are welcome! Feel free to open an issue or submit a pull request with improvements or new scripts. Please include documentation for any new tools.

--- a/src/Write-Status.ps1
+++ b/src/Write-Status.ps1
@@ -1,12 +1,39 @@
-<##
+<#
 .SYNOPSIS
 Writes a formatted status message and logs it to a file.
+
 .DESCRIPTION
-Outputs colored status messages for different log levels and appends them to a log file under the repository's /logs folder. The log file path is stored in the script-scoped variable `$script:StatusLogFile`.
+`Write-Status` routes log messages through the appropriate PowerShell cmdlets
+(`Write-Verbose`, `Write-Debug`, `Write-Warning`, `Write-Error`) so standard
+preference variables control what is displayed. Messages are also appended to a
+log file. A default log file is created under the repository's `logs` folder but
+the path can be overridden via the `LogFile` parameter.
+
 .PARAMETER Level
-The level of the message: INFO, WARN, ERROR or SUCCESS.
+The level of the message: INFO, WARN, ERROR, SUCCESS or DEBUG.
+
 .PARAMETER Message
-The message text to display and log.
+The message text to display and log. Accepts pipeline input.
+
+.PARAMETER LogFile
+Path to the log file. Defaults to a timestamped log under the repository's
+`logs` directory.
+
+.PARAMETER Fast
+Skips colored console output for faster logging.
+
+.EXAMPLE
+Write-Status -Level INFO -Message 'Build started'
+
+.EXAMPLE
+'Completed' | Write-Status -Level SUCCESS -LogFile 'C:\temp\run.log'
+
+.EXAMPLE
+Write-Status -Level ERROR -Message 'Failed' -Fast
+
+This function maps the provided level to `Write-Verbose`, `Write-Debug`,
+`Write-Warning` and `Write-Error` internally so `$VerbosePreference` and
+`$DebugPreference` affect console output.
 #>
 
 if (-not $script:StatusLogFile) {
@@ -19,30 +46,64 @@ if (-not $script:StatusLogFile) {
     $script:StatusLogFile = Join-Path -Path $logDir -ChildPath "$timestamp.log"
 }
 
-function Write-Status {
+function global:Write-Status {
     [CmdletBinding()]
     param(
         [Parameter(Mandatory)]
-        [ValidateSet('INFO','WARN','ERROR','SUCCESS')]
+        [ValidateSet('INFO','WARN','ERROR','SUCCESS','DEBUG')]
         [string]$Level,
-        [Parameter(Mandatory)]
-        [string]$Message
+
+        [Parameter(Mandatory, ValueFromPipeline, ValueFromPipelineByPropertyName)]
+        [string]$Message,
+
+        [string]$LogFile = $script:StatusLogFile,
+
+        [switch]$Fast
     )
 
-    switch ($Level) {
-        'INFO'    { Write-Host $Message -ForegroundColor Cyan }
-        'WARN'    { Write-Warning $Message }
-        'ERROR'   { Write-Error $Message }
-        'SUCCESS' { Write-Host $Message -ForegroundColor Green }
-    }
+    process {
+        if ($LogFile -ne $script:StatusLogFile) {
+            $script:StatusLogFile = $LogFile
+        }
 
-    $time = Get-Date -Format 'yyyy-MM-dd HH:mm:ss'
-    $symbol = switch ($Level) {
-        'INFO'    { '-' }
-        'WARN'    { '!' }
-        'ERROR'   { 'X' }
-        'SUCCESS' { '+' }
+        $time = Get-Date -Format 'yyyy-MM-dd HH:mm:ss'
+        $symbol = switch ($Level) {
+            'INFO'    { '-' }
+            'WARN'    { '!' }
+            'ERROR'   { 'X' }
+            'SUCCESS' { '+' }
+            'DEBUG'   { '*' }
+        }
+        $entry = "$time [$symbol] $Message"
+        Add-Content -Path $script:StatusLogFile -Value $entry -Encoding utf8
+
+        if ($Fast) {
+            switch ($Level) {
+                'INFO'    { Write-Verbose $Message }
+                'DEBUG'   { Write-Debug   $Message }
+                'WARN'    { Write-Warning $Message }
+                'ERROR'   { Write-Error   $Message }
+                'SUCCESS' { Write-Verbose $Message }
+            }
+        }
+        else {
+            switch ($Level) {
+                'INFO' {
+                    if ($VerbosePreference -ne 'SilentlyContinue') {
+                        Write-Host $Message -ForegroundColor Cyan
+                    }
+                    Write-Verbose $Message
+                }
+                'DEBUG'   { Write-Debug   $Message }
+                'WARN'    { Write-Warning $Message }
+                'ERROR'   { Write-Error   $Message }
+                'SUCCESS' {
+                    if ($VerbosePreference -ne 'SilentlyContinue') {
+                        Write-Host $Message -ForegroundColor Green
+                    }
+                    Write-Verbose $Message
+                }
+            }
+        }
     }
-    $entry = "$time [$symbol] $Message"
-    Add-Content -Path $script:StatusLogFile -Value $entry -Encoding utf8
 }

--- a/tests/Check-Dependencies.Tests.ps1
+++ b/tests/Check-Dependencies.Tests.ps1
@@ -1,9 +1,10 @@
 Describe 'Check-Dependencies script' {
     It 'succeeds when dependencies are satisfied' {
         $scriptPath = Join-Path $PSScriptRoot '..' 'scripts' 'Check-Dependencies.ps1'
-        $result = pwsh -NoProfile -File $scriptPath 2>&1
+        $json = pwsh -NoProfile -Command "& '$scriptPath' | ConvertTo-Json" 2>&1
         $exitCode = $LASTEXITCODE
         $exitCode | Should -Be 0
-        ($result -join "`n") | Should -Match 'All dependencies are satisfied'
+        $result = $json | ConvertFrom-Json
+        ($result | Where-Object { $_.Status -in @('Missing','Error') }).Count | Should -Be 0
     }
 }


### PR DESCRIPTION
## Summary
- overhaul `Write-Status` to allow log path overrides and fast mode
- integrate with PowerShell preference variables
- document `Write-Status` usage in README
- adapt dependency check test for new output

## Testing
- `pwsh -Command Invoke-Pester`

------
https://chatgpt.com/codex/tasks/task_b_684f653d50fc8322b2805030aaa24998