### PR TITLE
Update prerequisites and fix dependency script

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,8 +24,7 @@ The `agents/` folder hosts TypeScript code while `src/` is reserved for PowerShe
 
 ## Prerequisites
 
-- Windows PowerShell 5.1 or [PowerShell](https://github.com/PowerShell/PowerShell) 7+
-- [Node.js](https://nodejs.org/) for running the TypeScript agents
+- [PowerShell](https://github.com/PowerShell/PowerShell) 7+
 
 ## Getting Started
 

--- a/scripts/Check-Dependencies.ps1
+++ b/scripts/Check-Dependencies.ps1
@@ -13,22 +13,6 @@ function Test-WriteStatusModulePath {
     }
 }
 
-function Import-WriteStatusModule {
-    [CmdletBinding()]
-    param (
-        [Parameter(Mandatory, ValueFromPipeline)]
-        [string]$Path
-    )
-    process {
-        try {
-            . $Path
-            Write-Status -Level INFO -Message "Write-Status module loaded from $Path"
-        } catch {
-            Write-Error "Failed to load Write-Status from $Path"
-            throw
-        }
-    }
-}
 
 function Test-PowerShellVersion {
     [CmdletBinding()]
@@ -103,7 +87,8 @@ function Test-DependencyState {
         $result = @()
 
         $writeStatusPath = Test-WriteStatusModulePath
-        $writeStatusPath | Import-WriteStatusModule
+        . $writeStatusPath
+        Write-Status -Level INFO -Message "Write-Status module loaded from $writeStatusPath"
 
         $versionCheck = Test-PowerShellVersion
         $result += $versionCheck


### PR DESCRIPTION
## Summary
- update README prerequisite section to require PowerShell 7+ only
- load `Write-Status` from the dependency check script so later functions can use it

## Testing
- `pwsh -Command Invoke-Pester`

------
https://chatgpt.com/codex/tasks/task_b_684f66b5ee3c83228cbe908ccf3fb680