### PR TITLE
Add auto-doc workflow

### DIFF
--- a/.github/workflows/auto-doc.yml
+++ b/.github/workflows/auto-doc.yml
@@ -1,0 +1,34 @@
+name: Auto Document README
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  auto-doc:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Generate documentation
+        uses: tj-actions/auto-doc@v3.6.0
+
+      - name: Verify changed files
+        id: verify
+        uses: tj-actions/verify-changed-files@v8.6
+        with:
+          files: |
+            README.md
+
+      - name: Commit changes
+        if: steps.verify.outputs.files_changed == 'true'
+        uses: stefanzweifel/git-auto-commit-action@v5
+        with:
+          branch: ${{ github.head_ref }}
+          commit_message: "chore: update README with auto-doc"
+          file_pattern: README.md

--- a/README.md
+++ b/README.md
@@ -75,6 +75,9 @@ Write-Status -Level WARN -Message 'Low disk space' -LogFile 'C:\temp\build.log'
 Contributions are welcome! Feel free to open an issue or submit a pull request with improvements or new scripts. Please include documentation for any new tools.
 Refer to `AGENTS.md` and `docs/PowerShell_Guidelines.md` for naming conventions and pipeline support when adding new PowerShell scripts.
 
+<!--doc_begin-->
+<!--doc_end-->
+
 ## License
 
 This project is licensed under the MIT License. See the [LICENSE](LICENSE) file for details.


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to auto update README using `tj-actions/auto-doc`
- mark README section for generated docs

## Testing
- `pwsh -Command Invoke-Pester`

------
https://chatgpt.com/codex/tasks/task_b_684f6acffa9c8322bfa41567bf9d22c1