### PR TITLE
Fix deprecation warning in auto-doc workflow

### DIFF
--- a/.github/workflows/auto-doc.yml
+++ b/.github/workflows/auto-doc.yml
@@ -20,14 +20,14 @@ jobs:
 
       - name: Verify changed files
         id: verify
-        uses: tj-actions/verify-changed-files@v8.6
+        uses: tj-actions/verify-changed-files@v20
         with:
           files: |
             README.md
 
       - name: Commit changes
         if: steps.verify.outputs.files_changed == 'true'
-        uses: stefanzweifel/git-auto-commit-action@v5
+        uses: stefanzweifel/git-auto-commit-action@v6
         with:
           branch: ${{ github.head_ref }}
           commit_message: "chore: update README with auto-doc"


### PR DESCRIPTION
## Summary
- update `verify-changed-files` action to v20
- update `git-auto-commit-action` to v6

## Testing
- `pwsh -Command Invoke-Pester`

------
https://chatgpt.com/codex/tasks/task_b_684f6c87c2548322984cb5c6755ed73d