### PR TITLE
Add CI Pester badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # ZTools
+[![CI Pester Tests](https://github.com/yourlastnamesoundslikeatypeofpasta/ZTools/actions/workflows/ci-pester-tests.yml/badge.svg)](https://github.com/yourlastnamesoundslikeatypeofpasta/ZTools/actions/workflows/ci-pester-tests.yml)
 
 ZTools is a collection of PowerShell utilities and experimental TypeScript agents used for automation tasks. The repository is currently a skeleton that will be populated with organized tools over time.
 


### PR DESCRIPTION
## Summary
- add badge linking to CI Pester workflow status in README

## Testing
- `pwsh -Command Invoke-Pester -Output Detailed`

------
https://chatgpt.com/codex/tasks/task_b_684f783f2f9883228bf6563ec20250fd