### PR TITLE
Enable coverage for Pester tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .vscode/launch.json
 .vscode/settings.json
 logs/
+coverage.xml

--- a/.pester.ps1
+++ b/.pester.ps1
@@ -1,0 +1,7 @@
+$configuration = New-PesterConfiguration
+$configuration.Run.Path = 'tests'
+$configuration.CodeCoverage.Enabled = $true
+$configuration.CodeCoverage.Path = @('src')
+$configuration.CodeCoverage.OutputFormat = 'JaCoCo'
+$configuration.CodeCoverage.OutputPath = 'coverage.xml'
+$configuration

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,4 +8,5 @@ All notable changes to this project will be documented in this file.
 - Expanded documentation with PowerShell guidelines and repository structure details ([PR #12](https://github.com/yourlastnamesoundslikeatypeofpasta/ZTools/pull/12), [PR #15](https://github.com/yourlastnamesoundslikeatypeofpasta/ZTools/pull/15)).
 - Added GitHub workflows for Pester tests and automated documentation generation ([PR #18](https://github.com/yourlastnamesoundslikeatypeofpasta/ZTools/pull/18), [PR #19](https://github.com/yourlastnamesoundslikeatypeofpasta/ZTools/pull/19), [PR #20](https://github.com/yourlastnamesoundslikeatypeofpasta/ZTools/pull/20)).
 - Documented modular architecture and system requirements ([PR #22](https://github.com/yourlastnamesoundslikeatypeofpasta/ZTools/pull/22)).
+- Enabled JaCoCo code coverage for Pester tests via `.pester.ps1`.
 - Initial repository setup with basic PowerShell tooling structure ([PR #2](https://github.com/yourlastnamesoundslikeatypeofpasta/ZTools/pull/2), [PR #3](https://github.com/yourlastnamesoundslikeatypeofpasta/ZTools/pull/3)).

--- a/README.md
+++ b/README.md
@@ -45,6 +45,17 @@ The `agents/` folder hosts TypeScript code, `src/` is reserved for PowerShell ut
    - PowerShell scripts are under `src/`
    - TypeScript agents are under `agents/`
 
+## Running Tests
+
+Pester tests live in the `tests/` folder. A configuration file `.pester.ps1`
+enables code coverage reporting. Run tests from the repository root:
+
+```bash
+pwsh -Command "Invoke-Pester -Configuration (./.pester.ps1)"
+```
+
+This command generates `coverage.xml` with a JaCoCo-style report.
+
 ## PowerShell Best Practices
 
 - Use comment-based help in each script so usage is clear.


### PR DESCRIPTION
## Summary
- add `.pester.ps1` to configure code coverage
- ignore generated `coverage.xml`
- document how to run tests with coverage in README
- note coverage in changelog

## Testing
- `pwsh -Command "Invoke-Pester -Configuration (./.pester.ps1)"`

------
https://chatgpt.com/codex/tasks/task_b_684f779c7c2c8322bcf661ce2c3ed059