### PR TITLE
Enable coverage output in Pester workflow

### DIFF
--- a/.github/workflows/ci-pester-tests.yml
+++ b/.github/workflows/ci-pester-tests.yml
@@ -20,7 +20,8 @@ jobs:
       - name: Run Pester tests
         shell: pwsh
         run: |
-          Invoke-Pester -Path ./tests -Output Detailed -CI
+          $Config = ./.pester.ps1
+          Invoke-Pester -Configuration $Config -Output Detailed -CI
       - name: Upload test artifacts
         if: always()
         uses: actions/upload-artifact@v4
@@ -29,4 +30,5 @@ jobs:
           path: |
             **/TestResult*.xml
             **/Pester.TestResults.xml
+            coverage.xml
           if-no-files-found: ignore

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,4 +9,5 @@ All notable changes to this project will be documented in this file.
 - Added GitHub workflows for Pester tests and automated documentation generation ([PR #18](https://github.com/yourlastnamesoundslikeatypeofpasta/ZTools/pull/18), [PR #19](https://github.com/yourlastnamesoundslikeatypeofpasta/ZTools/pull/19), [PR #20](https://github.com/yourlastnamesoundslikeatypeofpasta/ZTools/pull/20)).
 - Documented modular architecture and system requirements ([PR #22](https://github.com/yourlastnamesoundslikeatypeofpasta/ZTools/pull/22)).
 - Enabled JaCoCo code coverage for Pester tests via `.pester.ps1`.
+- Updated CI workflow to include code coverage results for Pester tests.
 - Initial repository setup with basic PowerShell tooling structure ([PR #2](https://github.com/yourlastnamesoundslikeatypeofpasta/ZTools/pull/2), [PR #3](https://github.com/yourlastnamesoundslikeatypeofpasta/ZTools/pull/3)).


### PR DESCRIPTION
## Summary
- run Pester with repository `.pester.ps1` config
- upload coverage report from CI
- document CI code coverage update in CHANGELOG

## Testing
- `Invoke-Pester -Configuration (./.pester.ps1)`

------
https://chatgpt.com/codex/tasks/task_b_684f7aeccf288322ab35e88fdac066f6