### PR TITLE
Update changelog workflow

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,14 +30,8 @@ Pull request summaries should mention notable changes and reference any tests ru
 
 - Update `CHANGELOG.md` in every pull request.
 - Add a bullet under the `Unreleased` section describing the change.
-- After the description, append the UTC timestamp and link to the pull request in square brackets.
-  Example:
-
-  ```
-  - Improved dependency handling [2025-04-01 12:00 UTC](https://github.com/yourlastnamesoundslikeatypeofpasta/ZTools/pull/42)
-  ```
-
-- If the PR number is unknown when committing, update the entry once the PR is opened.
+- Do **not** include a timestamp or link to the pull request.
+- The changelog can be updated again after the pull request is merged if needed.
 
 ## Dependencies
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,5 +11,6 @@ All notable changes to this project will be documented in this file.
 - Enabled JaCoCo code coverage for Pester tests via `.pester.ps1`.
 - Updated CI workflow to include code coverage results for Pester tests.
 - Initial repository setup with basic PowerShell tooling structure ([PR #2](https://github.com/yourlastnamesoundslikeatypeofpasta/ZTools/pull/2), [PR #3](https://github.com/yourlastnamesoundslikeatypeofpasta/ZTools/pull/3)).
-- Documented changelog update process [2025-06-16 02:05 UTC](https://github.com/yourlastnamesoundslikeatypeofpasta/ZTools/pull/??)
+- Documented changelog update process to remove timestamp and PR link requirement
+- Updated AGENTS guidelines to drop timestamp and PR link requirement for changelog entries
 - Added ZtCore orchestrator and domain module folders with initial README files.


### PR DESCRIPTION
## Summary
- document that CHANGELOG entries no longer require timestamps or PR links
- note new process in `CHANGELOG.md`

## Testing
- `Invoke-Pester`

------
https://chatgpt.com/codex/tasks/task_b_684f7dfe18808322bd3143187d91088f