### PR TITLE
Fix Pester run in CI

### DIFF
--- a/.github/workflows/ci-pester-tests.yml
+++ b/.github/workflows/ci-pester-tests.yml
@@ -21,7 +21,7 @@ jobs:
         shell: pwsh
         run: |
           $Config = ./.pester.ps1
-          Invoke-Pester -Configuration $Config -Output Detailed -CI
+          Invoke-Pester -Configuration $Config
       - name: Upload test artifacts
         if: always()
         uses: actions/upload-artifact@v4

--- a/.pester.ps1
+++ b/.pester.ps1
@@ -4,4 +4,8 @@ $configuration.CodeCoverage.Enabled = $true
 $configuration.CodeCoverage.Path = @('src')
 $configuration.CodeCoverage.OutputFormat = 'JaCoCo'
 $configuration.CodeCoverage.OutputPath = 'coverage.xml'
+$configuration.Run.Exit = $true
+$configuration.TestResult.Enabled = $true
+$configuration.TestResult.OutputPath = 'Pester.TestResults.xml'
+$configuration.Output.Verbosity = 'Detailed'
 $configuration

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to this project will be documented in this file.
 - Documented modular architecture and system requirements ([PR #22](https://github.com/yourlastnamesoundslikeatypeofpasta/ZTools/pull/22)).
 - Enabled JaCoCo code coverage for Pester tests via `.pester.ps1`.
 - Updated CI workflow to include code coverage results for Pester tests.
+- Fixed Pester execution in GitHub Actions by relying on configuration instead of the `-CI` parameter.
 - Initial repository setup with basic PowerShell tooling structure ([PR #2](https://github.com/yourlastnamesoundslikeatypeofpasta/ZTools/pull/2), [PR #3](https://github.com/yourlastnamesoundslikeatypeofpasta/ZTools/pull/3)).
 - Documented changelog update process to remove timestamp and PR link requirement
 - Updated AGENTS guidelines to drop timestamp and PR link requirement for changelog entries


### PR DESCRIPTION
## Summary
- fix GitHub Actions Pester call so it works with coverage
- exit with an error if tests fail and store results in `Pester.TestResults.xml`

## Testing
- `Invoke-Pester -Configuration (./.pester.ps1)`

------
https://chatgpt.com/codex/tasks/task_b_684f7f92cad08322bd3e3e8b11f7714b