### PR TITLE
Add ZtEntity base class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,3 +17,4 @@ All notable changes to this project will be documented in this file.
 - Added ZtCore orchestrator and domain module folders with initial README files.
 - Clarified API roadmap in AGENTS.md [2025-06-16 02:18 UTC](https://github.com/yourlastnamesoundslikeatypeofpasta/ZTools/pull/??)
 - Added guidance to display progress bars for long-running tasks in AGENTS.md.
+- Added ZtEntity base class for cross-module data exchange.

--- a/src/ZtCore/ZtEntity.ps1
+++ b/src/ZtCore/ZtEntity.ps1
@@ -1,0 +1,26 @@
+<#
+.SYNOPSIS
+Base class representing a generic entity passed between modules.
+
+.DESCRIPTION
+`ZtEntity` defines minimal fields that modules use to exchange objects.
+Additional properties can be attached in the `Properties` hashtable so
+specialized modules remain interoperable.
+
+.EXAMPLE
+$entity = [ZtEntity]::new('ActiveDirectory','User','jsmith', @{ DisplayName = 'John Smith' })
+#>
+
+class ZtEntity {
+    [string]   $Source
+    [string]   $ObjectType
+    [string]   $Identifier
+    [hashtable]$Properties
+
+    ZtEntity([string]$Source, [string]$ObjectType, [string]$Identifier, [hashtable]$Properties) {
+        $this.Source      = $Source
+        $this.ObjectType  = $ObjectType
+        $this.Identifier  = $Identifier
+        $this.Properties  = $Properties
+    }
+}


### PR DESCRIPTION
## Summary
- define `ZtEntity` class used for cross-module communication
- document the new base class in `CHANGELOG.md`

## Testing
- `pwsh -Command "Invoke-Pester -Output Detailed"`

------
https://chatgpt.com/codex/tasks/task_b_684f812ea6c48322b042e9293403961b