### PR TITLE
Add Configure-SharePoint credential setup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to this project will be documented in this file.
 - Introduced Write-Status logging utilities and dependency checking script with Pester tests ([PR #8](https://github.com/yourlastnamesoundslikeatypeofpasta/ZTools/pull/8), [PR #9](https://github.com/yourlastnamesoundslikeatypeofpasta/ZTools/pull/9), [PR #21](https://github.com/yourlastnamesoundslikeatypeofpasta/ZTools/pull/21)).
 - Expanded documentation with PowerShell guidelines and repository structure details ([PR #12](https://github.com/yourlastnamesoundslikeatypeofpasta/ZTools/pull/12), [PR #15](https://github.com/yourlastnamesoundslikeatypeofpasta/ZTools/pull/15)).
 - Added `Install-ZTools` script to load all modules and optionally run a configuration script.
+- Added `Configure-SharePoint` script to save tenant and app credentials in Credential Manager.
 - Added GitHub workflows for Pester tests and automated documentation generation ([PR #18](https://github.com/yourlastnamesoundslikeatypeofpasta/ZTools/pull/18), [PR #19](https://github.com/yourlastnamesoundslikeatypeofpasta/ZTools/pull/19), [PR #20](https://github.com/yourlastnamesoundslikeatypeofpasta/ZTools/pull/20)).
 - Documented modular architecture and system requirements ([PR #22](https://github.com/yourlastnamesoundslikeatypeofpasta/ZTools/pull/22)).
 - Enabled JaCoCo code coverage for Pester tests via `.pester.ps1`.

--- a/src/Configure-SharePoint.ps1
+++ b/src/Configure-SharePoint.ps1
@@ -1,0 +1,67 @@
+<#
+.SYNOPSIS
+Prompts for SharePoint configuration and stores it in Windows Credential Manager.
+
+.DESCRIPTION
+Asks for the SharePoint tenant ID, app registration credential and user
+credential. The values are saved as credentials under the names
+`ZTools.SharePoint.TenantId`, `ZTools.SharePoint.Client` and
+`ZTools.SharePoint.User` so they persist across reboots.
+
+.PARAMETER TenantId
+Optional tenant identifier. If omitted a prompt is shown.
+
+.PARAMETER ClientCredential
+App registration credential where the user name is the client ID and the
+password is the client secret. If not supplied the user is prompted.
+
+.PARAMETER UserCredential
+User credential used for Graph or PnP connections. If not supplied the user is
+prompted.
+
+.EXAMPLE
+./Configure-SharePoint.ps1
+Prompts for all values and saves them in the credential manager.
+#>
+function Set-SharePointConfig {
+    [CmdletBinding()]
+    param(
+        [string]$TenantId,
+        [PSCredential]$ClientCredential,
+        [PSCredential]$UserCredential
+    )
+
+    begin {
+        $writeStatusPath = Join-Path -Path $PSScriptRoot -ChildPath 'Write-Status.ps1'
+        . $writeStatusPath
+        Import-Module CredentialManager -ErrorAction Stop
+    }
+    process {
+        if (-not $TenantId) {
+            $TenantId = Read-Host -Prompt 'Enter SharePoint Tenant ID'
+        }
+
+        if (-not $ClientCredential) {
+            $ClientCredential = Get-Credential -Message 'Enter Client ID as username and Client Secret as password'
+        }
+
+        if (-not $UserCredential) {
+            $UserCredential = Get-Credential -Message 'Enter SharePoint user credentials'
+        }
+
+        try {
+            New-StoredCredential -Target 'ZTools.SharePoint.TenantId' -Type Generic -UserName 'TenantId' -Password $TenantId -Persist LocalMachine | Out-Null
+            New-StoredCredential -Target 'ZTools.SharePoint.Client' -Credentials $ClientCredential -Persist LocalMachine | Out-Null
+            New-StoredCredential -Target 'ZTools.SharePoint.User' -Credentials $UserCredential -Persist LocalMachine | Out-Null
+            Write-Status -Level SUCCESS -Message 'Configuration stored in Credential Manager.' -Fast
+        } catch {
+            Write-Status -Level ERROR -Message $_.Exception.Message -Fast
+            throw
+        }
+    }
+}
+
+# Entry point - only run when the script is not dot-sourced
+if ($MyInvocation.InvocationName -ne '.') {
+    Set-SharePointConfig @PSBoundParameters
+}

--- a/tests/Configure-SharePoint.Tests.ps1
+++ b/tests/Configure-SharePoint.Tests.ps1
@@ -1,0 +1,7 @@
+Describe 'Configure-SharePoint script' {
+    It 'imports Set-SharePointConfig function' {
+        $scriptPath = Join-Path $PSScriptRoot '..' 'src' 'Configure-SharePoint.ps1'
+        . $scriptPath
+        Get-Command -Name Set-SharePointConfig -ErrorAction Stop | Should -Not -BeNullOrEmpty
+    }
+}


### PR DESCRIPTION
## Summary
- add Configure-SharePoint setup script for storing SharePoint config in Credential Manager
- cover new script with a Pester test
- document the new script in the changelog

## Testing
- `pwsh -Command Invoke-Pester`

------
https://chatgpt.com/codex/tasks/task_b_684f89117f4883228b6be325b181c080