### PR TITLE
Add missing Pester tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,3 +21,4 @@ All notable changes to this project will be documented in this file.
 - Clarified API roadmap in AGENTS.md [2025-06-16 02:18 UTC](https://github.com/yourlastnamesoundslikeatypeofpasta/ZTools/pull/??)
 - Added guidance to display progress bars for long-running tasks in AGENTS.md.
 - Added ZtEntity base class for cross-module data exchange.
+- Added Pester tests for Set-SharePointConfig, Install-ZTools configuration script handling and ZtEntity.

--- a/tests/Configure-SharePoint.Tests.ps1
+++ b/tests/Configure-SharePoint.Tests.ps1
@@ -5,3 +5,44 @@ Describe 'Configure-SharePoint script' {
         Get-Command -Name Set-SharePointConfig -ErrorAction Stop | Should -Not -BeNullOrEmpty
     }
 }
+
+Describe 'Set-SharePointConfig function' {
+    BeforeAll {
+        $scriptPath = Join-Path $PSScriptRoot '..' 'src' 'Configure-SharePoint.ps1'
+        . $scriptPath
+    }
+
+    BeforeEach {
+        function New-StoredCredential {}
+        function Import-Module {}
+        Mock New-StoredCredential {}
+        Mock Import-Module {}
+    }
+
+    It 'stores credentials when parameters are provided' {
+        $sec = ConvertTo-SecureString 'pass' -AsPlainText -Force
+        $cred = [pscredential]::new('user',$sec)
+        Set-SharePointConfig -TenantId 'tenant' -ClientCredential $cred -UserCredential $cred
+        Assert-MockCalled -CommandName New-StoredCredential -Times 3
+    }
+
+    It 'prompts for missing values' {
+        $sec = ConvertTo-SecureString 'pass' -AsPlainText -Force
+        $cred = [pscredential]::new('user',$sec)
+        Mock Get-Credential { $cred }
+        Mock Read-Host { 'tenant' }
+        Set-SharePointConfig
+        Assert-MockCalled -CommandName Get-Credential -Times 2
+        Assert-MockCalled -CommandName Read-Host -Times 1
+    }
+
+    It 'logs error when credential storage fails' {
+        $sec = ConvertTo-SecureString 'pass' -AsPlainText -Force
+        $cred = [pscredential]::new('user',$sec)
+        Mock New-StoredCredential { throw 'fail' }
+        Mock Write-Status {}
+        { Set-SharePointConfig -TenantId 'tenant' -ClientCredential $cred -UserCredential $cred } | Should -Throw
+        Assert-MockCalled -CommandName Write-Status -ParameterFilter { $Level -eq 'ERROR' } -Times 1
+    }
+}
+

--- a/tests/Install-ZTools.Tests.ps1
+++ b/tests/Install-ZTools.Tests.ps1
@@ -5,3 +5,13 @@ Describe 'Install-ZTools' {
         Get-Command -Name Write-Status -ErrorAction Stop | Should -Not -BeNullOrEmpty
     }
 }
+
+Describe 'Install-ZTools configuration script handling' {
+    BeforeAll {
+        $scriptPath = Join-Path $PSScriptRoot '..' 'src' 'Install-ZTools.ps1'
+    }
+    It 'does not throw when configuration script missing' {
+        { . $scriptPath -ConfigScript (Join-Path $TestDrive 'missing.ps1') } | Should -Not -Throw
+    }
+}
+

--- a/tests/ZtEntity.Tests.ps1
+++ b/tests/ZtEntity.Tests.ps1
@@ -1,0 +1,13 @@
+Describe 'ZtEntity class' {
+    It 'stores constructor parameters' {
+        $scriptPath = Join-Path $PSScriptRoot '..' 'src' 'ZtCore' 'ZtEntity.ps1'
+        . $scriptPath
+        $props = @{ Foo = 'Bar' }
+        $entity = [ZtEntity]::new('Source','User','id',$props)
+        $entity.Source | Should -Be 'Source'
+        $entity.ObjectType | Should -Be 'User'
+        $entity.Identifier | Should -Be 'id'
+        $entity.Properties['Foo'] | Should -Be 'Bar'
+    }
+}
+


### PR DESCRIPTION
## Summary
- add tests covering Set-SharePointConfig function
- add test ensuring Install-ZTools handles missing config script
- add ZtEntity class tests
- document new tests in changelog

## Testing
- `pwsh -Command Invoke-Pester -Output Normal`

------
https://chatgpt.com/codex/tasks/task_b_684f8d801e9c83228dcf4da61b8ab830