### PR TITLE
Add Export-ProductKey utility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,3 +25,4 @@ All notable changes to this project will be documented in this file.
 - Added Pester tests for Set-SharePointConfig, Install-ZTools configuration script handling and ZtEntity.
 - Added EntraID module with functions to query Microsoft Graph and return `ZtEntity` objects.
 - Documented Start-ThreadJob usage for background tasks in AGENTS.md.
+- Added `Export-ProductKey` function to retrieve the Windows product key.

--- a/src/SupportTools/Export-ProductKey.ps1
+++ b/src/SupportTools/Export-ProductKey.ps1
@@ -1,0 +1,71 @@
+<#
+.SYNOPSIS
+Exports the Windows product key to a file.
+
+.DESCRIPTION
+Retrieves the original product key from the SoftwareLicensingService WMI class
+and writes it to the specified path. Optionally logs a transcript of the session.
+
+.PARAMETER OutputPath
+Destination file path for the exported product key.
+
+.PARAMETER TranscriptPath
+Optional path to create a transcript log.
+
+.EXAMPLE
+Export-ProductKey -OutputPath ./key.txt
+
+.NOTES
+Administrator privileges are required to query the licensing service.
+#>
+function Export-ProductKey {
+    [CmdletBinding(SupportsShouldProcess=$true)]
+    param(
+        [Parameter(Mandatory)]
+        [ValidateNotNullOrEmpty()]
+        [string]$OutputPath,
+
+        [Parameter(Mandatory=$false)]
+        [ValidateNotNullOrEmpty()]
+        [string]$TranscriptPath
+    )
+
+    try {
+        if ($TranscriptPath) { Start-Transcript -Path $TranscriptPath -Append | Out-Null }
+
+        try {
+            $key = Get-CimInstance -ClassName SoftwareLicensingService -ErrorAction Stop |
+                   Select-Object -ExpandProperty OA3xOriginalProductKey
+        } catch {
+            Write-Error $_.Exception.Message
+            throw
+        }
+
+        if (-not $key) {
+            Write-Status -Level WARN -Message 'Product key not found.' -Fast
+            return
+        }
+
+        if (-not $PSCmdlet.ShouldProcess($OutputPath, 'Export product key')) { return }
+
+        try {
+            Set-Content -Path $OutputPath -Value $key -ErrorAction Stop
+        } catch {
+            Write-Error $_.Exception.Message
+            throw
+        }
+
+        Write-Status -Level SUCCESS -Message "Product key exported to $OutputPath" -Fast
+        return [pscustomobject]@{
+            ProductKey = $key
+            OutputPath = $OutputPath
+        }
+    } finally {
+        if ($TranscriptPath) { Stop-Transcript | Out-Null }
+    }
+}
+
+# Entry point
+if ($MyInvocation.InvocationName -ne '.') {
+    Export-ProductKey @PSBoundParameters
+}

--- a/tests/Export-ProductKey.Tests.ps1
+++ b/tests/Export-ProductKey.Tests.ps1
@@ -1,0 +1,38 @@
+Describe 'Export-ProductKey function' {
+    BeforeAll {
+        $corePath = Join-Path $PSScriptRoot '..' 'src'
+        . (Join-Path $corePath 'Write-Status.ps1')
+        . (Join-Path $corePath 'SupportTools' 'Export-ProductKey.ps1')
+    }
+
+    BeforeEach {
+        Mock Write-Status {}
+        Mock Start-Transcript {}
+        Mock Stop-Transcript {}
+        function Get-CimInstance {}
+        Mock Set-Content {}
+        Mock Get-CimInstance { [pscustomobject]@{ OA3xOriginalProductKey = 'ABCDE-12345' } }
+    }
+
+    It 'writes product key to specified path and returns key' {
+        $path = Join-Path $TestDrive 'key.txt'
+        $result = Export-ProductKey -OutputPath $path
+        Assert-MockCalled -CommandName Set-Content -Times 1 -ParameterFilter { $Path -eq $path -and $Value -eq 'ABCDE-12345' }
+        Assert-MockCalled -CommandName Write-Status -ParameterFilter { $Level -eq 'SUCCESS' }
+        $result.ProductKey | Should -Be 'ABCDE-12345'
+    }
+
+    It 'logs warning when product key not found' {
+        Mock Get-CimInstance { $null }
+        $path = Join-Path $TestDrive 'missing.txt'
+        Export-ProductKey -OutputPath $path
+        Assert-MockCalled -CommandName Write-Status -ParameterFilter { $Level -eq 'WARN' } -Times 1
+        Assert-MockCalled -CommandName Set-Content -Times 0
+    }
+
+    It 'does not write file when WhatIf is used' {
+        $path = Join-Path $TestDrive 'whatif.txt'
+        Export-ProductKey -OutputPath $path -WhatIf
+        Assert-MockCalled -CommandName Set-Content -Times 0
+    }
+}


### PR DESCRIPTION
## Summary
- add `Export-ProductKey` function under `SupportTools`
- write Pester tests for exporting a product key
- document the new feature in CHANGELOG

## Testing
- `pwsh -Command Invoke-Pester`

------
https://chatgpt.com/codex/tasks/task_b_684f9897eabc83229898377c4a55d469