### PR TITLE
Add help section for dependency script

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ All notable changes to this project will be documented in this file.
 - Added `Configure-SharePoint` script to save tenant and app credentials in Credential Manager.
 - Added GitHub workflows for Pester tests and automated documentation generation ([PR #18](https://github.com/yourlastnamesoundslikeatypeofpasta/ZTools/pull/18), [PR #19](https://github.com/yourlastnamesoundslikeatypeofpasta/ZTools/pull/19), [PR #20](https://github.com/yourlastnamesoundslikeatypeofpasta/ZTools/pull/20)).
 - Documented modular architecture and system requirements ([PR #22](https://github.com/yourlastnamesoundslikeatypeofpasta/ZTools/pull/22)).
+- Added comment-based help for `Check-Dependencies.ps1` describing module and PowerShell version checks.
 - Enabled JaCoCo code coverage for Pester tests via `.pester.ps1`.
 - Updated CI workflow to include code coverage results for Pester tests.
 - Fixed Pester execution in GitHub Actions by relying on configuration instead of the `-CI` parameter.

--- a/scripts/Check-Dependencies.ps1
+++ b/scripts/Check-Dependencies.ps1
@@ -1,3 +1,22 @@
+<#
+.SYNOPSIS
+Checks that required PowerShell modules are installed and verifies the
+PowerShell version.
+
+.DESCRIPTION
+`Check-Dependencies.ps1` loads the repository's `Write-Status.ps1` logger and
+then runs a series of tests. It ensures PowerShell 7 or higher is in use and
+that core modules such as Pester, PnP.PowerShell, ExchangeOnlineManagement,
+Microsoft.Graph and ActiveDirectory are available. Each check outputs a status
+object summarizing the result.
+
+.EXAMPLE
+PS> ./Check-Dependencies.ps1
+Runs the dependency checks and returns a list of status objects indicating
+which modules are installed and whether the PowerShell version meets the
+requirement.
+#>
+
 function Test-WriteStatusModulePath {
     [CmdletBinding()]
     param()


### PR DESCRIPTION
## Summary
- document usage for `Check-Dependencies.ps1`
- note new help section in changelog

## Testing
- `pwsh -Command Invoke-Pester`

------
https://chatgpt.com/codex/tasks/task_b_684f9ac549a483228226fc9f2f8d94f0