### PR TITLE
Clarify changelog entry placement

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -52,8 +52,9 @@ Pull request summaries should mention notable changes and reference any tests ru
 
 - Update `CHANGELOG.md` in every pull request.
 - Add a bullet under the `Unreleased` section describing the change.
-- After the description, include the pull request number in parentheses,
-  for example `(PR #42)`.
+  Append it at the end of the list to reduce merge conflicts.
+- After the description, include the pull request number in parentheses.
+  Leave the number blank when opening the pull request, for example `(PR #)`.
 - The changelog can be updated again after the pull request is merged if needed.
 
 ## Dependencies

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,3 +26,4 @@ All notable changes to this project will be documented in this file.
 - Added EntraID module with functions to query Microsoft Graph and return `ZtEntity` objects. (PR #48)
 - Documented Start-ThreadJob usage for background tasks in AGENTS.md. (PR #47)
 - Added `Export-ProductKey` function to retrieve the Windows product key. (PR #49)
+- Documented leaving the pull request number blank and appending entries to the end of the changelog in AGENTS instructions. (PR #)


### PR DESCRIPTION
## Summary
- note in `AGENTS.md` that Unreleased bullets should be appended at the end
- log this change in the changelog

## Testing
- `pwsh -Command Invoke-Pester`


------
https://chatgpt.com/codex/tasks/task_b_684f9d662acc832293df6c52804e6ce7