### PR TITLE
Fix PowerShell Guidelines link references

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,3 +28,4 @@ All notable changes to this project will be documented in this file.
 - Added `Export-ProductKey` function to retrieve the Windows product key. (PR #49)
 - Moved `Check-Dependencies` script under `src` and updated references. (PR #)
 - Removed duplicate `PowerShell-Guidelines.md` and updated references. (PR #)
+- Verified cleanup of old `docs/PowerShell-Guidelines.md` references. (PR #)


### PR DESCRIPTION
## Summary
- document cleanup of PowerShell-Guidelines.md filename

## Testing
- `pwsh -Command Invoke-Pester`

------
https://chatgpt.com/codex/tasks/task_b_684f9eeabb148322be996e6944d195ef