### PR TITLE
Use background job for Install-ZTools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,3 +28,4 @@ All notable changes to this project will be documented in this file.
 - Added `Export-ProductKey` function to retrieve the Windows product key. (PR #49)
 - Moved `Check-Dependencies` script under `src` and updated references. (PR #)
 - Removed duplicate `PowerShell-Guidelines.md` and updated references. (PR #)
+- Updated `Install-ZTools` to load module files using a background thread and moved the ThreadJob import. (PR #)


### PR DESCRIPTION
## Summary
- load module files via background thread job in `Install-ZTools`
- move `ThreadJob` module import to file header

## Testing
- `pwsh -Command Invoke-Pester`


------
https://chatgpt.com/codex/tasks/task_b_684f9ed4938c8322b6f1afd1934509ed