### PR TITLE
Update README with repo URL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,3 +41,4 @@ All notable changes to this project will be documented in this file.
 - Added PowerShell_References document with links to key module documentation. (PR #)
 - Clarified PowerShell function guidelines in `AGENTS.md`, including when to use
   `Begin`, `Process`, and `End` blocks. (PR #)
+- Documented repository URL in README clone instructions. (PR #)

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ The `agents/` folder hosts TypeScript code, `src/` is reserved for PowerShell ut
 
 1. **Clone the repository**
    ```bash
-   git clone <repo-url>
+   git clone https://github.com/yourlastnamesoundslikeatypeofpasta/ZTools.git
    cd ZTools
    ```
 2. **Browse the tools**


### PR DESCRIPTION
## Summary
- add the GitHub repository URL to the clone instructions in README
- document the change in CHANGELOG

## Testing
- `pwsh -Command "Invoke-Pester -Configuration (./.pester.ps1)"`

------
https://chatgpt.com/codex/tasks/task_b_684fadadae8c8322b9d7c83296474a4a