### PR TITLE
Update Write-Status INFO symbol

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,3 +41,4 @@ All notable changes to this project will be documented in this file.
 - Added PowerShell_References document with links to key module documentation. (PR #)
 - Clarified PowerShell function guidelines in `AGENTS.md`, including when to use
   `Begin`, `Process`, and `End` blocks. (PR #)
+- Updated Write-Status to use '>' for INFO messages and adjusted tests. (PR #)

--- a/src/Write-Status.ps1
+++ b/src/Write-Status.ps1
@@ -172,7 +172,7 @@ function global:Write-Status {
 
         $time = Get-Date -Format 'yyyy-MM-dd HH:mm:ss'
         $symbol = switch ($Level) {
-            'INFO'    { '-' }
+            'INFO'    { '>' }
             'WARN'    { '!' }
             'ERROR'   { 'X' }
             'SUCCESS' { '+' }

--- a/tests/Write-Status.Tests.ps1
+++ b/tests/Write-Status.Tests.ps1
@@ -18,9 +18,9 @@ Describe 'Write-Status' {
             Test-Path $script:StatusLogFile | Should -BeTrue
         }
 
-        It 'logs INFO with minus symbol' {
+        It 'logs INFO with greater-than symbol' {
             Write-Status -Level INFO -Message 'info message'
-            (Get-Content $script:StatusLogFile | Select-Object -Last 1) | Should -Match '\[-\] info message'
+            (Get-Content $script:StatusLogFile | Select-Object -Last 1) | Should -Match '\[>\] info message'
         }
 
         It 'logs WARN with exclamation symbol' {
@@ -95,8 +95,8 @@ Describe 'Write-Status' {
         It 'logs multiple pipeline messages individually' {
             @('one','two') | Write-Status -Level INFO
             $content = Get-Content $script:StatusLogFile
-            ($content | Select-String '\[\-\] one').Count | Should -BeGreaterThan 0
-            ($content | Select-String '\[\-\] two').Count | Should -BeGreaterThan 0
+            ($content | Select-String '\[>\] one').Count | Should -BeGreaterThan 0
+            ($content | Select-String '\[>\] two').Count | Should -BeGreaterThan 0
         }
     }
 }


### PR DESCRIPTION
## Summary
- use `>` for INFO entries in `Write-Status`
- adjust `Write-Status` tests
- document the change in `CHANGELOG`

## Testing
- `pwsh -Command Invoke-Pester`


------
https://chatgpt.com/codex/tasks/task_b_684fae1521588322a51f65ba50082cde