### PR TITLE
Add configurable logging options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project will be documented in this file.
 - Updated MonitoringTools tests for Windows compatibility.
 - Added additional Pester tests for dependency checking functions. (PR #41)
 - Updated Test-RequiredModules to run module checks in parallel using thread jobs and added new tests. (PR #)
+- Added Set-WriteStatusConfig to customize logging paths and updated README with examples. (PR #)
 - Updated Pester CI workflow to run on all pull requests. (PR #44)
 - Added AGENTS guidelines and modular TypeScript agent framework (PR #1, PR #4).
 - Introduced Write-Status logging utilities and dependency checking script with Pester tests (PR #8, PR #9, PR #21).

--- a/README.md
+++ b/README.md
@@ -88,6 +88,12 @@ Write-Status -Level INFO -Message 'Starting build'
 # Redirect logs
 Write-Status -Level WARN -Message 'Low disk space' -LogFile 'C:\temp\build.log'
 
+# Change default log locations
+Set-WriteStatusConfig -LogDirectory 'C:\logs' -ErrorLogFile 'C:\logs\error.log'
+
+# Use a different logging tool
+Write-Status -Level INFO -Message 'forwarded log' -LogFile (Join-Path $logs 'app.log') | Tee-Object 'C:\logs\full.log'
+
 # Pipeline support
 'Finished' | Write-Status -Level SUCCESS -Fast
 ```

--- a/src/Write-Status.ps1
+++ b/src/Write-Status.ps1
@@ -7,7 +7,8 @@ Writes a formatted status message and logs it to a file.
 (`Write-Verbose`, `Write-Debug`, `Write-Warning`, `Write-Error`) so standard
 preference variables control what is displayed. Messages are also appended to a
 log file. A default log file is created under the repository's `logs` folder but
-the path can be overridden via the `LogFile` parameter.
+the path can be overridden via the `LogFile` parameter. Call
+`Set-WriteStatusConfig` to change the default log directory or error log path.
 
 .PARAMETER Level
 The level of the message: INFO, WARN, ERROR, SUCCESS or DEBUG.
@@ -41,6 +42,36 @@ $script:LogDirectory   = Join-Path -Path $repoRoot -ChildPath 'logs'
 $script:ErrorLogFile   = Join-Path -Path $script:LogDirectory -ChildPath 'error.log'
 $script:StatusLogFile  = $null
 $script:LogHour        = $null
+
+function Set-WriteStatusConfig {
+    <#
+    .SYNOPSIS
+    Sets default paths used by Write-Status.
+
+    .PARAMETER LogDirectory
+    Directory where hourly logs are created.
+
+    .PARAMETER ErrorLogFile
+    Path to the persistent error log.
+    #>
+    [CmdletBinding()]
+    param(
+        [string]$LogDirectory,
+        [string]$ErrorLogFile
+    )
+
+    if ($PSBoundParameters.ContainsKey('LogDirectory')) {
+        $script:LogDirectory = $LogDirectory
+    }
+
+    if ($PSBoundParameters.ContainsKey('ErrorLogFile')) {
+        $script:ErrorLogFile = $ErrorLogFile
+    }
+
+    # Reset rotating log file so new settings take effect
+    $script:StatusLogFile = $null
+    $script:LogHour       = $null
+}
 
 function New-LogDirectory {
     <#

--- a/tests/Write-Status.Tests.ps1
+++ b/tests/Write-Status.Tests.ps1
@@ -5,8 +5,7 @@ Describe 'Write-Status' {
     }
 
     BeforeEach {
-        $script:LogDirectory = Join-Path $TestDrive 'logs'
-        $script:ErrorLogFile = Join-Path $script:LogDirectory 'error.log'
+        Set-WriteStatusConfig -LogDirectory (Join-Path $TestDrive 'logs') -ErrorLogFile (Join-Path $TestDrive 'logs' 'error.log')
         $script:StatusLogFile = $null
         $script:LogHour = $null
     }
@@ -85,7 +84,7 @@ Describe 'Write-Status' {
         It 'rotates log file when hour changes' {
             Write-Status -Level INFO -Message 'first'
             $first = $script:StatusLogFile
-            $script:LogDirectory = Join-Path $TestDrive 'rotated'
+            Set-WriteStatusConfig -LogDirectory (Join-Path $TestDrive 'rotated')
             $script:StatusLogFile = $null
             $script:LogHour = '1990-01-01_00'
             Write-Status -Level INFO -Message 'second'


### PR DESCRIPTION
## Summary
- allow configuring Write-Status log locations through new `Set-WriteStatusConfig`
- document overriding log paths in README
- update tests for new config function
- note change in changelog

## Testing
- `pwsh -NoProfile -Command "Invoke-Pester -Configuration (./.pester.ps1)"`

------
https://chatgpt.com/codex/tasks/task_b_684fae7629808322afb19776cf9ade28