### PR TITLE
Remove duplicate API bullet

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,7 +10,6 @@ The project is hosted at [https://github.com/yourlastnamesoundslikeatypeofpasta/
 - Handle failures gracefully with `try/catch` blocks and fallback logic.
 - Secure configuration using PowerShell credential management and sign scripts when possible.
 - Unit test new features after implementation to maintain reliability.
-- Plan for an API layer so these tools can be accessed by web or GPT-based clients.
 
 ## Module Development Roadmap
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,3 +45,4 @@ All notable changes to this project will be documented in this file.
 - Removed auto documentation workflow and composite action file. (PR #)
 - Updated Write-Status to use '>' for INFO messages and adjusted tests. (PR #)
 - Documented repository URL in README clone instructions. (PR #)
+- Removed duplicate bullet about API layer from Architecture section in AGENTS guidelines. (PR #)


### PR DESCRIPTION
## Summary
- prune the duplicate API bullet in Architecture
- record change in `CHANGELOG`

## Testing
- `pwsh -Command Invoke-Pester`

------
https://chatgpt.com/codex/tasks/task_b_684fb10fd3788322b1d53575a5a111a9