### PR TITLE
Update dependency check instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -47,7 +47,7 @@ interfaces.
 - Document new or updated agents in `agents/AGENT_ROLES.md`.
  - Run the agents using your preferred workflow (for example `ts-node`). Currently no automated tests exist for this code.
 
-The repository uses Pester for testing PowerShell scripts. If any tests exist under the `tests/` directory, run them with `pwsh -Command Invoke-Pester` before committing. If Pester is not installed, install it via PowerShell's `Install-Module -Name Pester -Force`.
+The repository uses Pester for testing PowerShell scripts. Before running any tests or scripts, execute `src/Check-Dependencies.ps1` to confirm required modules are available. If any tests exist under the `tests/` directory, run them with `pwsh -Command Invoke-Pester` before committing. If Pester is not installed, install it via PowerShell's `Install-Module -Name Pester -Force`.
 
 Pull request summaries should mention notable changes and reference any tests run.
 
@@ -69,7 +69,7 @@ Most tools rely on several PowerShell modules. Ensure the following modules are 
 - `Microsoft.Graph`
 - `ActiveDirectory` (requires RSAT tools)
 
-Run `src/Check-Dependencies.ps1` to verify that your environment meets these requirements.
+Run `src/Check-Dependencies.ps1` before running tests or scripts to verify that your environment meets these requirements.
 
 ## Background Thread Jobs
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,3 +45,4 @@ All notable changes to this project will be documented in this file.
 - Removed auto documentation workflow and composite action file. (PR #)
 - Updated Write-Status to use '>' for INFO messages and adjusted tests. (PR #)
 - Documented repository URL in README clone instructions. (PR #)
+- Instructed contributors to run `src/Check-Dependencies.ps1` before running tests or scripts. (PR #)

--- a/README.md
+++ b/README.md
@@ -52,8 +52,12 @@ The `agents/` folder hosts TypeScript code, `src/` is reserved for PowerShell ut
    # or
    Import-Module ./src/ZTools/ZTools.psd1
    ```
+4. **Check dependencies**
+   Run `src/Check-Dependencies.ps1` before using the tools to ensure all required modules are installed.
 
 ## Running Tests
+
+Before running tests, execute `src/Check-Dependencies.ps1` to verify all required modules are available.
 
 Pester tests live in the `tests/` folder. A configuration file `.pester.ps1`
 enables code coverage reporting. Run tests from the repository root:


### PR DESCRIPTION
## Summary
- remind contributors to run `src/Check-Dependencies.ps1` before tests or scripts
- mention dependency check in Getting Started and Running Tests docs
- document change in `CHANGELOG`

## Testing
- `pwsh -NoLogo -Command ./src/Check-Dependencies.ps1`
- `pwsh -NoLogo -Command Invoke-Pester`

------
https://chatgpt.com/codex/tasks/task_b_684fb122daf483228b0e1f85eeeabe24