### PR TITLE
Refactor credential storage to SecretStore

### DIFF
--- a/tests/Configure-SharePoint.Tests.ps1
+++ b/tests/Configure-SharePoint.Tests.ps1
@@ -13,9 +13,9 @@ Describe 'Set-SharePointConfig function' {
     }
 
     BeforeEach {
-        function New-StoredCredential {}
+        function Set-Secret {}
         function Import-Module {}
-        Mock New-StoredCredential {}
+        Mock Set-Secret {}
         Mock Import-Module {}
     }
 
@@ -23,7 +23,7 @@ Describe 'Set-SharePointConfig function' {
         $sec = ConvertTo-SecureString 'pass' -AsPlainText -Force
         $cred = [pscredential]::new('user',$sec)
         Set-SharePointConfig -TenantId 'tenant' -ClientCredential $cred -UserCredential $cred
-        Assert-MockCalled -CommandName New-StoredCredential -Times 3
+        Assert-MockCalled -CommandName Set-Secret -Times 3
     }
 
     It 'prompts for missing values' {
@@ -39,7 +39,7 @@ Describe 'Set-SharePointConfig function' {
     It 'logs error when credential storage fails' {
         $sec = ConvertTo-SecureString 'pass' -AsPlainText -Force
         $cred = [pscredential]::new('user',$sec)
-        Mock New-StoredCredential { throw 'fail' }
+        Mock Set-Secret { throw 'fail' }
         Mock Write-Status {}
         { Set-SharePointConfig -TenantId 'tenant' -ClientCredential $cred -UserCredential $cred } | Should -Throw
         Assert-MockCalled -CommandName Write-Status -ParameterFilter { $Level -eq 'ERROR' } -Times 1

--- a/tests/Get-SDTicket.Tests.ps1
+++ b/tests/Get-SDTicket.Tests.ps1
@@ -14,13 +14,16 @@ Describe 'Get-SDTicket function' {
         . (Join-Path $root 'SolarWindsSD' 'Set-SDConfig.ps1')
         . (Join-Path $root 'SolarWindsSD' 'Get-SDTicket.ps1')
         Mock Invoke-RestMethod { @{ id = 1 } }
-        function New-StoredCredential {}
-        function Get-StoredCredential {}
+        function Set-Secret {}
+        function Get-Secret {}
+        function Get-SecretInfo {}
         function Import-Module {}
-        Mock New-StoredCredential {}
+        Mock Set-Secret {}
         Mock Import-Module {}
-        Mock Get-StoredCredential {
-            [pscustomobject]@{ Password = if ($Target -match 'ApiToken') { 'token' } else { 'https://api.samanage.com' } }
+        Mock Get-SecretInfo { $true }
+        Mock Get-Secret {
+            $value = if ($Name -match 'ApiToken') { 'token' } else { 'https://api.samanage.com' }
+            [pscredential]::new('user', (ConvertTo-SecureString $value -AsPlainText -Force))
         }
         Set-SDConfig -BaseUrl 'https://api.samanage.com' -ApiToken 'token'
         New-SDSession

--- a/tests/Set-SDConfig.Tests.ps1
+++ b/tests/Set-SDConfig.Tests.ps1
@@ -15,15 +15,15 @@ Describe 'Set-SDConfig function' {
         Remove-Item function:Set-SDConfig -ErrorAction Ignore
         . (Join-Path $root 'ZtCore' 'ZtEntity.ps1')
         . (Join-Path $root 'SolarWindsSD' 'Set-SDConfig.ps1')
-        function New-StoredCredential {}
+        function Set-Secret {}
         function Import-Module {}
-        Mock New-StoredCredential {}
+        Mock Set-Secret {}
         Mock Import-Module {}
     }
 
     It 'stores values when parameters are provided' {
         Set-SDConfig -BaseUrl 'https://api.samanage.com' -ApiToken 'token'
-        Assert-MockCalled -CommandName New-StoredCredential -Times 2
+        Assert-MockCalled -CommandName Set-Secret -Times 2
     }
 
     It 'prompts for missing values' {
@@ -33,7 +33,7 @@ Describe 'Set-SDConfig function' {
     }
 
     It 'logs error when storage fails' {
-        Mock New-StoredCredential { throw 'fail' }
+        Mock Set-Secret { throw 'fail' }
         Mock Write-Status {}
         { Set-SDConfig -BaseUrl 'url' -ApiToken 'token' } | Should -Throw
         Assert-MockCalled -CommandName Write-Status -ParameterFilter { $Level -eq 'ERROR' } -Times 1

--- a/tests/Set-SDTicket.Tests.ps1
+++ b/tests/Set-SDTicket.Tests.ps1
@@ -14,13 +14,16 @@ Describe 'Set-SDTicket function' {
         . (Join-Path $root 'SolarWindsSD' 'Set-SDConfig.ps1')
         . (Join-Path $root 'SolarWindsSD' 'Set-SDTicket.ps1')
         Mock Invoke-RestMethod { @{ success = $true } }
-        function New-StoredCredential {}
-        function Get-StoredCredential {}
+        function Set-Secret {}
+        function Get-Secret {}
+        function Get-SecretInfo {}
         function Import-Module {}
-        Mock New-StoredCredential {}
+        Mock Set-Secret {}
         Mock Import-Module {}
-        Mock Get-StoredCredential {
-            [pscustomobject]@{ Password = if ($Target -match 'ApiToken') { 'token' } else { 'https://api.samanage.com' } }
+        Mock Get-SecretInfo { $true }
+        Mock Get-Secret {
+            $value = if ($Name -match 'ApiToken') { 'token' } else { 'https://api.samanage.com' }
+            [pscredential]::new('user', (ConvertTo-SecureString $value -AsPlainText -Force))
         }
         Set-SDConfig -BaseUrl 'https://api.samanage.com' -ApiToken 'token'
         New-SDSession


### PR DESCRIPTION
## Summary
- migrate to SecretManagement SecretStore for configuration
- use `Set-Secret` and `Get-Secret` in SolarWinds and SharePoint scripts
- update Pester tests for SecretManagement

## Testing
- `./src/Check-Dependencies.ps1`
- `Invoke-Pester -Configuration (./.pester.ps1)`

------
https://chatgpt.com/codex/tasks/task_b_6853183917f8832289048d501000ec0d