### PR TITLE
Ensure SecretManagement is a dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ The `agents/` folder hosts TypeScript code, `src/` is reserved for PowerShell ut
 - [ExchangeOnlineManagement](https://www.powershellgallery.com/packages/ExchangeOnlineManagement)
 - [Microsoft.Graph](https://www.powershellgallery.com/packages/Microsoft.Graph)
 - [ActiveDirectory](https://www.powershellgallery.com/packages/ActiveDirectory) (requires RSAT)
+- [Microsoft.PowerShell.SecretManagement](https://www.powershellgallery.com/packages/Microsoft.PowerShell.SecretManagement)
 
 ## Getting Started
 

--- a/docs/PowerShell_References.md
+++ b/docs/PowerShell_References.md
@@ -6,5 +6,6 @@ This file lists key documentation links for modules commonly used in ZTools.
 - [Microsoft Graph PowerShell](https://learn.microsoft.com/en-us/powershell/microsoftgraph/navigating?view=graph-powershell-1.0)
 - [Exchange Online PowerShell](https://learn.microsoft.com/en-us/powershell/exchange/connect-to-exchange-online-powershell?view=exchange-ps)
 - [Microsoft Places PowerShell](https://learn.microsoft.com/en-us/microsoft-365/places/powershell/connect-microsoftplaces)
+- [SecretManagement](https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.secretmanagement/?view=ps-modules)
 
 Refer to these resources when creating or updating modules that rely on these services.

--- a/src/Check-Dependencies.ps1
+++ b/src/Check-Dependencies.ps1
@@ -6,7 +6,8 @@ Checks the PowerShell version and required modules.
 `Check-Dependencies.ps1` loads `Write-Status.ps1` and verifies that the
 current session is running PowerShell 7 or later. It then checks for the
 presence of several required modules including `Pester`, `PnP.PowerShell`,
-`ExchangeOnlineManagement`, `Microsoft.Graph` and `ActiveDirectory`. Status
+`ExchangeOnlineManagement`, `Microsoft.Graph`, `ActiveDirectory`, and
+`Microsoft.PowerShell.SecretManagement`. Status
 messages are written for each check so missing modules or an insufficient
 PowerShell version are clearly reported.
 
@@ -134,7 +135,8 @@ function Test-DependencyState {
             'PnP.PowerShell',
             'ExchangeOnlineManagement',
             'Microsoft.Graph',
-            'ActiveDirectory'
+            'ActiveDirectory',
+            'Microsoft.PowerShell.SecretManagement'
         )
         $moduleResults = $requiredModules | Test-RequiredModules
         $result += $moduleResults

--- a/tests/Check-Dependencies.Tests.ps1
+++ b/tests/Check-Dependencies.Tests.ps1
@@ -3,7 +3,7 @@ Describe 'Check-Dependencies script' {
         $scriptPath = Join-Path $PSScriptRoot '..' 'src' 'Check-Dependencies.ps1'
         $result = & $scriptPath
 
-        $expected = 'Pester','PnP.PowerShell','ExchangeOnlineManagement','Microsoft.Graph','ActiveDirectory'
+        $expected = 'Pester','PnP.PowerShell','ExchangeOnlineManagement','Microsoft.Graph','ActiveDirectory','Microsoft.PowerShell.SecretManagement'
         foreach ($mod in $expected) {
             ($result | Where-Object { $_.Check -eq $mod }).Count | Should -Be 1
         }


### PR DESCRIPTION
## Summary
- update dependency documentation with Microsoft.PowerShell.SecretManagement
- check for SecretManagement in Check-Dependencies script and tests
- add reference link for SecretManagement docs

## Testing
- `pwsh -NoLogo -NoProfile -Command ./src/Check-Dependencies.ps1 | head`
- `pwsh -NoLogo -NoProfile -Command "Invoke-Pester -Configuration (./.pester.ps1)" > pester.log && tail -n 20 pester.log`

------
https://chatgpt.com/codex/tasks/task_b_68531dc53f388322a4116bedeab85a15