### PR TITLE
Fix Set-SDConfig to register SecretStore

### DIFF
--- a/src/SolarWindsSD/README.md
+++ b/src/SolarWindsSD/README.md
@@ -5,5 +5,5 @@ PowerShell cmdlets for interacting with the SolarWinds Service Desk REST API. Th
 - API General Concepts: <https://apidoc.samanage.com/#section/General-Concepts>
 - Full OpenAPI Schema: <https://apidoc.samanage.com/redoc/schema/resolved_schema.json>
 
-Run `Set-SDConfig` once to store your base URL and API token in Windows Credential Manager. Subsequent calls to `New-SDSession` will automatically read these values if no parameters are supplied.
+Run `Set-SDConfig` once to store your base URL and API token in the SecretStore vault provided by PowerShell SecretManagement. Subsequent calls to `New-SDSession` will automatically read these values if no parameters are supplied.
 All cmdlets return `[ZtEntity]` objects so they can be piped into other ZTools modules.


### PR DESCRIPTION
## Summary
- ensure Set-SDConfig registers a SecretStore vault when needed
- update docs to mention SecretManagement vault

## Testing
- `./src/Check-Dependencies.ps1`
- `Invoke-Pester -Configuration (./.pester.ps1)`

------
https://chatgpt.com/codex/tasks/task_b_685328680fd483229695170b04817bb2