### PR TITLE
Add import banner

### DIFF
--- a/src/Show-ImportBanner.ps1
+++ b/src/Show-ImportBanner.ps1
@@ -1,0 +1,22 @@
+<#
+.SYNOPSIS
+Displays the ZTools import banner.
+.DESCRIPTION
+Shows an ASCII art banner when the module is imported.
+#>
+function Show-ImportBanner {
+    [CmdletBinding()]
+    param()
+    $banner = @'
+ _________         _      _                     _          _
+|_  /_   _|__  ___| |___ (_)_ __  _ __  ___ _ _| |_ ___ __| |
+ / /  | |/ _ \/ _ \ (_-< | | '  \| '_ \/ _ \ '_|  _/ -_) _` |
+/___| |_|\___/\___/_/__/ |_|_|_|_| .__/\___/_|  \__\___\__,_|
+                                 |_|
+'@
+    Write-Host $banner -ForegroundColor Green
+    return $banner
+}
+
+# Entry point executed on import
+Show-ImportBanner | Out-Null

--- a/tests/Show-ImportBanner.Tests.ps1
+++ b/tests/Show-ImportBanner.Tests.ps1
@@ -1,0 +1,10 @@
+Describe 'Show-ImportBanner' {
+    BeforeAll {
+        $scriptPath = Join-Path $PSScriptRoot '..' 'src' 'Show-ImportBanner.ps1'
+        . $scriptPath
+    }
+    It 'returns banner string' {
+        $result = Show-ImportBanner
+        $result | Should -BeOfType String
+    }
+}


### PR DESCRIPTION
## Summary
- show a banner when the ZTools module imports
- add Pester tests for the new banner function

## Testing
- `pwsh -Command "./src/Check-Dependencies.ps1"`
- `pwsh -Command "Invoke-Pester -Configuration (./.pester.ps1)"`

------
https://chatgpt.com/codex/tasks/task_b_685327a7ee248322b2273f692c581f85