### PR TITLE
Add starter manifests

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -92,3 +92,13 @@ $job = Get-Job | Where Name -eq ThreadJob  # or capture the returned job
 $job | Wait-Job
 $items = $job | Receive-Job
 ```
+
+## Release process
+
+- Use [Semantic Versioning](https://semver.org/) for all modules.
+- Each module should have a `.psd1` manifest with `ModuleVersion` starting at `0.1.0`.
+- Include a `.VERSION` tag in comment-based help for each function.
+- Increment the major version for breaking changes, minor for new features, and patch for fixes.
+- Bump versions in the same pull request that introduces the change and ensure the PR description reflects these updates.
+- `CHANGELOG.md` is generated from pull request titles, so keep them descriptive.
+- After merging to `main`, tag the repository with the module version to mark the release.

--- a/src/EntraID/EntraID.psd1
+++ b/src/EntraID/EntraID.psd1
@@ -1,0 +1,13 @@
+@{
+    RootModule        = ''
+    ModuleVersion     = '0.1.0'
+    GUID              = 'd3933142-9a5d-4e9c-9fcd-a5d7639a783c'
+    Author            = 'ZTools'
+    CompanyName       = 'ZTools'
+    Copyright         = 'Copyright (c) ZTools'
+    Description       = 'Helpers for Microsoft Entra ID queries.'
+    FunctionsToExport = '*'
+    CmdletsToExport   = @()
+    AliasesToExport   = '*'
+    VariablesToExport = '*'
+}

--- a/src/MonitoringTools/MonitoringTools.psd1
+++ b/src/MonitoringTools/MonitoringTools.psd1
@@ -1,0 +1,13 @@
+@{
+    RootModule        = ''
+    ModuleVersion     = '0.1.0'
+    GUID              = '26f55be9-0b30-47bb-98cc-1e94cc5ac7e0'
+    Author            = 'ZTools'
+    CompanyName       = 'ZTools'
+    Copyright         = 'Copyright (c) ZTools'
+    Description       = 'Monitoring tools for system health checks.'
+    FunctionsToExport = '*'
+    CmdletsToExport   = @()
+    AliasesToExport   = '*'
+    VariablesToExport = '*'
+}

--- a/src/SolarWindsSD/SolarWindsSD.psd1
+++ b/src/SolarWindsSD/SolarWindsSD.psd1
@@ -1,0 +1,13 @@
+@{
+    RootModule        = ''
+    ModuleVersion     = '0.1.0'
+    GUID              = 'c148bbb4-b681-46c3-844e-6902f50504ce'
+    Author            = 'ZTools'
+    CompanyName       = 'ZTools'
+    Copyright         = 'Copyright (c) ZTools'
+    Description       = 'Utilities for SolarWinds Service Desk integration.'
+    FunctionsToExport = '*'
+    CmdletsToExport   = @()
+    AliasesToExport   = '*'
+    VariablesToExport = '*'
+}

--- a/src/SupportTools/SupportTools.psd1
+++ b/src/SupportTools/SupportTools.psd1
@@ -1,0 +1,13 @@
+@{
+    RootModule        = ''
+    ModuleVersion     = '0.1.0'
+    GUID              = '33f99010-2409-49b6-8a42-687f4c2a65c2'
+    Author            = 'ZTools'
+    CompanyName       = 'ZTools'
+    Copyright         = 'Copyright (c) ZTools'
+    Description       = 'Support scripts for system maintenance.'
+    FunctionsToExport = '*'
+    CmdletsToExport   = @()
+    AliasesToExport   = '*'
+    VariablesToExport = '*'
+}

--- a/src/ZtCore/ZtCore.psd1
+++ b/src/ZtCore/ZtCore.psd1
@@ -1,0 +1,13 @@
+@{
+    RootModule        = ''
+    ModuleVersion     = '0.1.0'
+    GUID              = 'ef595730-29c6-46ba-a220-2fe183c8ec43'
+    Author            = 'ZTools'
+    CompanyName       = 'ZTools'
+    Copyright         = 'Copyright (c) ZTools'
+    Description       = 'Core orchestration module for combining tools.'
+    FunctionsToExport = '*'
+    CmdletsToExport   = @()
+    AliasesToExport   = '*'
+    VariablesToExport = '*'
+}


### PR DESCRIPTION
## Summary
- create module manifests for EntraID, MonitoringTools, SolarWindsSD, SupportTools and ZtCore
- clarify release process instructions about starting version

## Testing
- `pwsh -NoLogo -Command ./src/Check-Dependencies.ps1` *(fails: `pwsh` not found)*
- `pwsh -NoLogo -Command "Invoke-Pester -Configuration (./.pester.ps1)"` *(fails: `pwsh` not found)*

------
https://chatgpt.com/codex/tasks/task_b_685329e0a69c832295356ed3732d1b26