### PR TITLE
Add PDF renaming watcher module

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ The `agents/` folder hosts TypeScript code, `src/` is reserved for PowerShell ut
 2. **Browse the tools**
    - PowerShell scripts are under `src/`
    - TypeScript agents are under `agents/`
+   - The `PdfTools` module provides `Start-PdfRenameWatcher` for automatic PDF renaming.
 3. **Load the modules**
    Run `Install-ZTools.ps1` to import all scripts or import the `ZTools` module manifest. Optionally provide a configuration script:
    ```powershell

--- a/src/PdfTools/PdfTools.psd1
+++ b/src/PdfTools/PdfTools.psd1
@@ -1,0 +1,13 @@
+@{
+    RootModule        = ''
+    ModuleVersion     = '0.1.0'
+    GUID              = '60f39188-8a64-4489-ae4b-a2aae14453a0'
+    Author            = 'ZTools'
+    CompanyName       = 'ZTools'
+    Copyright         = 'Copyright (c) ZTools'
+    Description       = 'PDF utilities including automated renaming.'
+    FunctionsToExport = '*'
+    CmdletsToExport   = @()
+    AliasesToExport   = '*'
+    VariablesToExport = '*'
+}

--- a/src/PdfTools/README.md
+++ b/src/PdfTools/README.md
@@ -1,0 +1,7 @@
+# PdfTools Module
+
+The PdfTools module contains utilities for working with PDF files. Currently it provides a watcher that automatically renames PDFs using the OpenAI API.
+
+## Commands
+
+- `Start-PdfRenameWatcher` - Monitors a folder and renames newly created PDF files based on their contents.

--- a/src/PdfTools/Start-PdfRenameWatcher.ps1
+++ b/src/PdfTools/Start-PdfRenameWatcher.ps1
@@ -1,0 +1,131 @@
+<#
+.SYNOPSIS
+    Watches a folder for new PDF files and renames them using OpenAI.
+.DESCRIPTION
+    Creates a FileSystemWatcher on the target folder. When a PDF file is dropped
+    into the directory, the document is uploaded to the OpenAI API and a short
+    descriptive name is requested. The file is then renamed to the suggested
+    name.
+.PARAMETER Path
+    Folder path to monitor for PDF files.
+.PARAMETER OpenAIKey
+    API key used when calling the OpenAI service.
+.PARAMETER Model
+    Optional model name for the chat completion request.
+.EXAMPLE
+    Start-PdfRenameWatcher -Path 'C:\Drop' -OpenAIKey $env:OPENAI_API_KEY
+#>
+function Start-PdfRenameWatcher {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [string]$Path,
+
+        [Parameter(Mandatory)]
+        [string]$OpenAIKey,
+
+        [string]$Model = 'gpt-4-1106-preview'
+    )
+
+    begin {
+        $writeStatus = Join-Path -Path $PSScriptRoot -ChildPath '..\Write-Status.ps1'
+        . $writeStatus
+    }
+
+    process {
+        if (-not (Test-Path $Path)) {
+            Write-Status -Level ERROR -Message "Directory '$Path' not found."
+            return
+        }
+
+        $resolved = (Resolve-Path $Path).Path
+        $watcher = New-Object System.IO.FileSystemWatcher $resolved, '*.pdf'
+        $watcher.IncludeSubdirectories = $false
+        $watcher.EnableRaisingEvents = $true
+
+        Register-ObjectEvent -InputObject $watcher -EventName Created -SourceIdentifier PdfCreated -Action {
+            param($source, $eventArgs)
+            $file = $eventArgs.FullPath
+            Start-Sleep -Seconds 1
+            Write-Status -Level INFO -Message "Uploading $(Split-Path -Leaf $file)" -Fast
+            $id = Upload-OpenAIFile -Path $file -ApiKey $OpenAIKey
+            if (-not $id) { return }
+
+            Write-Status -Level INFO -Message 'Requesting new file name' -Fast
+            $name = Get-OpenAIPdfName -FileId $id -ApiKey $OpenAIKey -Model $Model
+            if (-not $name) { return }
+
+            $invalid = [System.IO.Path]::GetInvalidFileNameChars()
+            foreach ($c in $invalid) { $name = $name -replace [Regex]::Escape($c), '-' }
+            $destination = Join-Path -Path (Split-Path $file -Parent) -ChildPath "$name.pdf"
+
+            try {
+                Rename-Item -Path $file -NewName $destination -ErrorAction Stop
+                Write-Status -Level SUCCESS -Message "Renamed to $(Split-Path -Leaf $destination)" -Fast
+            } catch {
+                Write-Status -Level ERROR -Message $_.Exception.Message
+            }
+        }
+
+        Write-Status -Level INFO -Message "Watching '$resolved' for PDF files. Press Ctrl+C to stop."
+        while ($true) { Start-Sleep -Seconds 5 }
+    }
+}
+
+function Upload-OpenAIFile {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [string]$Path,
+        [Parameter(Mandatory)]
+        [string]$ApiKey
+    )
+    process {
+        try {
+            $uri = 'https://api.openai.com/v1/files'
+            $headers = @{ Authorization = "Bearer $ApiKey" }
+            $form = @{ file = Get-Item -Path $Path; purpose = 'assistants' }
+            Write-Progress -Activity 'Uploading PDF to OpenAI' -Status (Split-Path -Leaf $Path) -PercentComplete 0
+            $result = Invoke-RestMethod -Uri $uri -Method Post -Headers $headers -Form $form
+            Write-Progress -Activity 'Uploading PDF to OpenAI' -Completed
+            return $result.id
+        } catch {
+            Write-Status -Level ERROR -Message "Upload failed: $_"
+        }
+    }
+}
+
+function Get-OpenAIPdfName {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [string]$FileId,
+        [Parameter(Mandatory)]
+        [string]$ApiKey,
+        [string]$Model = 'gpt-4-1106-preview'
+    )
+    process {
+        try {
+            $uri = 'https://api.openai.com/v1/chat/completions'
+            $headers = @{ Authorization = "Bearer $ApiKey" }
+            $body = @{
+                model = $Model
+                messages = @(
+                    @{ role = 'system'; content = 'Provide a short descriptive filename based on the uploaded PDF. Return only the filename without extension.' },
+                    @{ role = 'user'; content = 'Use the provided PDF to generate a name.' }
+                )
+                file_ids = @($FileId)
+                max_tokens = 10
+            } | ConvertTo-Json -Depth 5
+            $response = Invoke-RestMethod -Uri $uri -Method Post -Headers $headers -ContentType 'application/json' -Body $body
+            return $response.choices[0].message.content.Trim()
+        } catch {
+            Write-Status -Level ERROR -Message "OpenAI request failed: $_"
+        }
+    }
+}
+
+# Entry point for direct execution
+if ($MyInvocation.InvocationName -eq $MyInvocation.MyCommand.Name) {
+    Start-PdfRenameWatcher @PSBoundParameters
+}

--- a/tests/Start-PdfRenameWatcher.Tests.ps1
+++ b/tests/Start-PdfRenameWatcher.Tests.ps1
@@ -1,0 +1,16 @@
+Describe 'Start-PdfRenameWatcher function' {
+    BeforeAll {
+        $core = Join-Path $PSScriptRoot '..' 'src'
+        . (Join-Path $core 'Write-Status.ps1')
+        . (Join-Path $core 'PdfTools' 'Start-PdfRenameWatcher.ps1')
+    }
+
+    BeforeEach {
+        Mock Write-Status {}
+    }
+
+    It 'logs error when directory is missing' {
+        Start-PdfRenameWatcher -Path 'Z:\missing' -OpenAIKey 'test' -Model 'test' -ErrorAction SilentlyContinue
+        Assert-MockCalled -CommandName Write-Status -ParameterFilter { $Level -eq 'ERROR' } -Times 1
+    }
+}


### PR DESCRIPTION
## Summary
- add **PdfTools** module with `Start-PdfRenameWatcher` to rename PDFs using OpenAI
- document PdfTools module in README
- include basic Pester test for the watcher

## Testing
- `pwsh -NoLogo -NoProfile -Command ./src/Check-Dependencies.ps1`
- `pwsh -NoLogo -NoProfile -Command "Invoke-Pester -Configuration (./.pester.ps1)"`

------
https://chatgpt.com/codex/tasks/task_b_686807fcedd88322982a79833440eb61